### PR TITLE
HW/SW Interface Document update

### DIFF
--- a/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
+++ b/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
@@ -166,20 +166,20 @@ Installed Robotpy Modules: commands2, navx, pathplannerlib, phoenix6
 
 The following table lists all the motor controllers used in the robot.
 
-| Function          | Controller  | FW          | Motor    | CAN Addr | PDP Port | Breaker |
-|-------------------|-------------|-------------|----------|:--------:|:--------:|:-------:|
-| Drive Front Left  | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    13    |  40 A   |
-| Drive Rear Left   | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    14    |  40 A   |
-| Drive Front Right | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    12    |  40 A   |
-| Drive Rear Right  | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    15    |  40 A   |
-| Steer Front Left  | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    10    |  30 A   |
-| Steer Rear Left   | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    9     |  30 A   |
-| Steer Front Right | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    11    |  30 A   |
-| Steer Rear Right  | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    8     |  30 A   |
-| Lift Right        | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |  _TBD_   |  40 A   |
-| Lift Left         | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |  _TBD_   |  40 A   |
-| Intake Pivot      | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |  _TBD_   |  40 A   |
-| Intake Feeder     | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |  _TBD_   |  40 A   |
+| Function          | Controller  | FW          | Motor       | CAN Addr | PDP Port | Breaker |
+|-------------------|-------------|-------------|-------------|:--------:|:--------:|:-------:|
+| Drive Front Left  | Talon FX    | 2024.1.0.0  | Kraken X60  |  _TBD_   |    13    |  40 A   |
+| Drive Rear Left   | Talon FX    | 2024.1.0.0  | Kraken X60  |  _TBD_   |    14    |  40 A   |
+| Drive Front Right | Talon FX    | 2024.1.0.0  | Kraken X60  |  _TBD_   |    12    |  40 A   |
+| Drive Rear Right  | Talon FX    | 2024.1.0.0  | Kraken X60  |  _TBD_   |    15    |  40 A   |
+| Steer Front Left  | Talon FX    | 2024.1.0.0  | Kraken X60  |  _TBD_   |    10    |  30 A   |
+| Steer Rear Left   | Talon FX    | 2024.1.0.0  | Kraken X60  |  _TBD_   |    9     |  30 A   |
+| Steer Front Right | Talon FX    | 2024.1.0.0  | Kraken X60  |  _TBD_   |    11    |  30 A   |
+| Steer Rear Right  | Talon FX    | 2024.1.0.0  | Kraken X60  |  _TBD_   |    8     |  30 A   |
+| Lift Right        | Talon FX    | 2024.1.0.0  | Falcon 500  |  _TBD_   |  _TBD_   |  40 A   |
+| Lift Left         | Talon FX    | 2024.1.0.0  | Falcon 500  |  _TBD_   |  _TBD_   |  40 A   |
+| Intake Pivot      | Talon FX    | 2024.1.0.0  | Falcon 500  |  _TBD_   |  _TBD_   |  40 A   |
+| Intake Feeder     | Talon FX    | 2024.1.0.0  | Falcon 500  |  _TBD_   |  _TBD_   |  40 A   |
 
 
 ## Discrete Sensors

--- a/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
+++ b/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
@@ -16,10 +16,11 @@ Robot Name: _TBD_
     * [Lift and Intake Rules](#lift-and-intake-rules)
   * [Robot Controllers](#robot-controllers)
   * [Motor Controllers](#motor-controllers)
-  * [Sensors](#sensors)
-  * [OpenMesh Radio](#openmesh-radio)
+  * [Discrete Sensors](#discrete-sensors)
+  * [Ethernet](#ethernet)
+    * [OpenMesh Radio](#openmesh-radio)
+    * [Limelight 3](#limelight-3)
   * [Useful Links](#useful-links)
-  * [Crimp Inspection Log](#crimp-inspection-log)
 <!-- TOC -->
 
 ## Software Repository

--- a/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
+++ b/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
@@ -141,7 +141,7 @@ A generic CTRE control system is shown below.
 
 ![](https://github.com/SteelRidgeRobotics/2023-2024_FRC_Season/blob/74a8d3010bef6135c66bc175156146020acc0bac/controls/hardware_software_interface_specifications/frc-control-system-layout.png)
 
-This robot uses a single RoboRIO 2 as the only robot controller.
+This robot uses a single roboRIO 2 as the only robot controller.
 The robot code is implemented in Python using the 2024 RobotPy framework.
 Major software versions are shown in the following table.
 Motor controller and sensor software versions are listed elsewhere in this document.

--- a/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
+++ b/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
@@ -23,7 +23,7 @@ Robot Name: _TBD_
 <!-- TOC -->
 
 ## Software Repository
-The robot source code can be found in this repository:
+The robot source code can be found in this repository: [Competition Robot Code](https://github.com/SteelRidgeRobotics/2024DumpsterFire)
 
 
 ## Description
@@ -31,7 +31,7 @@ The robot source code can be found in this repository:
 This document describes the interface between the hardware and software of the competition robot for the 2024 Crescendo FRC Season.
 The robot consists of a swerve drive chassis, an elevator mechanism, and an intake.
 The swerve drive uses the Swerve Drive Specialties MK4i module arranged on a square chassis.
-The elevator mechanism, known as the lift, consists of two telescoping lifts that support the Touch It, Own It (TITO) intake mechansim.
+The elevator mechanism, known as the lift, consists of two telescoping lifts that support the Touch It, Own It (TITO) intake mechanism.
 The lift also includes a pair of hooks that can allow the robot to climb the chain in the end game.
 The intake uses horizontal rollers that grab and hold on to the game piece.
 The intake pivots between a retracted position inside the frame perimeter and a deployed position that reaches over the bumper.
@@ -116,6 +116,9 @@ This list should be used to guide trade off decisions to ensure that lower prior
 2. Touch It, Own It (TIOI) Intake
 3. Amplifier Lift
 4. Climber
+5. Other
+
+"Other" development efforts include scoring in the TRAP and utilizing vision to improve teleop performance.
 
 ## Motion Control Rules
 
@@ -153,7 +156,7 @@ Motor controller and sensor software versions are listed elsewhere in this docum
 
 | Python Packages         | Version    |
 |-------------------------|------------|
-| robotpy                 | 2024.2.2.1 |
+| robotpy                 | 2024.2.1.1 |
 | frc6343                 | 0.2        |
  
 Installed Robotpy Modules: commands2, navx, pathplannerlib, phoenix6
@@ -162,57 +165,58 @@ Installed Robotpy Modules: commands2, navx, pathplannerlib, phoenix6
 
 The following table lists all the motor controllers used in the robot.
 
-| Function               | Controller  | FW          | Motor    | CAN Addr | PDP Port | Breaker |
-|------------------------|-------------|-------------|----------|:--------:|:--------:|:-------:|
-| Front Left Drive       | Talon FX    | 2024.1.0.0  | Falcon   |    0     |  _TBD_   |  40 A   |
-| Rear Left Drive        | Talon FX    | 2024.1.0.0  | Falcon   |    1     |  _TBD_   |  40 A   |
-| Front Right Drive      | Talon FX    | 2024.1.0.0  | Falcon   |    2     |  _TBD_   |  40 A   |
-| Rear Right Drive       | Talon FX    | 2024.1.0.0  | Falcon   |    3     |  _TBD_   |  40 A   |
-| Front Left Direction   | Talon FX    | 2024.1.0.0  | Falcon   |    4     |  _TBD_   |  30 A   |
-| Rear Left Direction    | Talon FX    | 2024.1.0.0  | Falcon   |    5     |  _TBD_   |  30 A   |
-| Front Right Direction  | Talon FX    | 2024.1.0.0  | Falcon   |    6     |  _TBD_   |  30 A   |
-| Rear Right Direction   | Talon FX    | 2024.1.0.0  | Falcon   |    7     |  _TBD_   |  30 A   |
-| Lift                   | Talon FX    | 2024.1.0.0  | Falcon   |    15    |  _TBD_   |  40 A   |
-| Intake Pivot           | Talon FX    | 2024.1.0.0  | Falcon   |    16    |  _TBD_   |  40 A   |
-| Intake Feeder          | Talon FX    | 2024.1.0.0  | Falcon   |    17    |  _TBD_   |  30 A   |
+| Function          | Controller  | FW          | Motor    | CAN Addr | PDP Port | Breaker |
+|-------------------|-------------|-------------|----------|:--------:|:--------:|:-------:|
+| Drive Front Left  | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    13    |  40 A   |
+| Drive Rear Left   | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    14    |  40 A   |
+| Drive Front Right | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    12    |  40 A   |
+| Drive Rear Right  | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    15    |  40 A   |
+| Steer Front Left  | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    10    |  30 A   |
+| Steer Rear Left   | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    9     |  30 A   |
+| Steer Front Right | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    11    |  30 A   |
+| Steer Rear Right  | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |    8     |  30 A   |
+| Lift Right        | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |  _TBD_   |  40 A   |
+| Lift Left         | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |  _TBD_   |  40 A   |
+| Intake Pivot      | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |  _TBD_   |  40 A   |
+| Intake Feeder     | Talon FX    | 2024.1.0.0  | Falcon   |  _TBD_   |  _TBD_   |  40 A   |
 
 
-## Sensors
+## Discrete Sensors
 
 The following table lists all the sensors used in the robot.
 
-| Function                     | Sensor              |     FW     | Associated Motor      | CAN Addr | PDP / VRM    | Breaker |
-|------------------------------|---------------------|:----------:|-----------------------|:--------:|--------------|:-------:|
-| Front Left Swerve Direction  | CANcoder            | 2024.1.0.0 | Front Left Direction  |    10    | VRM 5V/2A    |   ---   |
-| Rear Left Swerve Direction   | CANcoder            | 2024.1.0.0 | Rear Left Direction   |    11    | VRM 5V/2A    |   ---   |
-| Front Right Swerve Direction | CANcoder            | 2024.1.0.0 | Front Right Direction |    12    | VRM 5V/2A    |   ---   |
-| Rear Right Swerve Direction  | CANcoder            | 2024.1.0.0 | Rear Right Direction  |    13    | VRM 5V/2A    |   ---   |
-| Intake Feeder Beam Break     | Adafruit Beam Break |    ---     | Intake Feeder         |   ---    | VRM 5V/500mA |   ---   |
+| Function                 | Sensor              |     FW     | Associated Motor      | CAN Addr | PDP / VRM     |
+|--------------------------|---------------------|:----------:|-----------------------|:--------:|---------------|
+| Steer Front Left Swerve  | CANcoder            | 2024.1.0.0 | Front Left Direction  |    10    | VRM 12V/500mA |
+| Steer Rear Left Swerve   | CANcoder            | 2024.1.0.0 | Rear Left Direction   |    11    | VRM 12V/500mA |
+| Steer Front Right Swerve | CANcoder            | 2024.1.0.0 | Front Right Direction |    12    | VRM 12V/500mA |
+| Steer Rear Right Swerve  | CANcoder            | 2024.1.0.0 | Rear Right Direction  |    13    | VRM 12V/500mA |
+| Intake Feeder Beam Break | Adafruit Beam Break |    ---     | Intake Feeder         |   ---    | VRM 5V/500mA  |
 
 Notes:
-1.  The VRM is powered through a 20 A fuse at a dedicated port of the PDP.
+1.  The VRM is powered through a 20 A breaker at **PDP Port 4**.
 2.  Integrated sensors built into Falcon 500 motors are not included in this list.
 
-## OpenMesh Radio
+## Ethernet
 
-The OpenMesh radio is connected directly to the RoboRIO 2 through an Ethernet cable. The radio is powered from the
-The VRM's 12V, 2A output is connected to a Radio Power Module (RPM) with provides power to the radio through the Ethernet cable.
+A Brainbox SW-005 100Mbps Ethernet switch connects the roboRIO to the OpenMesh radio and the Limelight 3 vision module.
+
+| Device          |     PDP Port     | Breaker/ Fuse |
+|-----------------|:----------------:|:-------------:|
+| Ethernet Switch |        5         |     20 A      |
+| Limelight 3     |      _TBD_       |     20 A      |
+| OpenMesh Radio  | Vbat VRM PCM PWR |     20 A      |
+
+### OpenMesh Radio
+
+The OpenMesh radio is connected directly to the Radio Power Module through an Ethernet cable.
+Similarly, the Radio Power Module is connected directly to Ethernet Switch.
+The PDP's "Vbat VRM PCM PWR" output is connected to a Radio Power Module (RPM) with provides power to the radio through the Ethernet cable.
+
+### Limelight 3
+
+The Limelight vision module os connected directly to Ethernet Switch through an Ethernet cable.
 
 ## Useful Links
 
 [2024 Crescendo Game Resources](https://www.firstinspires.org/resource-library/frc/competition-manual-qa-system)
-
-## Crimp Inspection Log
-
-The following wiring crimps were inspected by someone certified in Basic Controls or an approved mentor.
-
-| No. | Color | Type | Description  | Technician | Inspector | Date |
-|-----|-------|------|--------------|------------|-----------|------|
-|     |       |      |              |            |           |      |
-|     |       |      |              |            |           |      |
-|     |       |      |              |            |           |      |
-
-Colors: K=Black, R=Red, Y=Yellow, B=Blue, W=White, G=Green
-
-Types: WR=Wire Ferrule, PP45=PowerPole 45, BS=Butt Splice, CL=6 AWG Compression Lug, PWM=PWM / DuPont, LNK=3M Link Connector
-

--- a/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
+++ b/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
@@ -131,7 +131,7 @@ These rule govern the interaction between the lift and intake mechanisms.
 The robot implements a CTRE style robot control system.
 A generic CTRE control system is shown below.
 
-![](https://github.com/SteelRidgeRobotics/2023-2024_FRC_Season/blob/controls/controls/hardware_software_interface_specifications/frc-control-system-layout.png)
+![](https://github.com/SteelRidgeRobotics/2023-2024_FRC_Season/blob/74a8d3010bef6135c66bc175156146020acc0bac/controls/hardware_software_interface_specifications/frc-control-system-layout.png)
 
 This robot uses a single RoboRIO 2 as the only robot controller.
 The robot code is implemented in Python using the 2024 RobotPy framework.

--- a/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
+++ b/controls/hardware_software_interface_specifications/competition_hw_sw_interface_spec.md
@@ -4,6 +4,7 @@ Robot Name: _TBD_
 
 <!-- TOC -->
 * [Hardware Software Interface Specification](#hardware-software-interface-specification)
+  * [Software Repository](#software-repository)
   * [Description](#description)
     * [Swerve Drive Mechanism](#swerve-drive-mechanism)
     * [Game Piece Handling Mechanisms](#game-piece-handling-mechanisms)
@@ -20,6 +21,10 @@ Robot Name: _TBD_
   * [Useful Links](#useful-links)
   * [Crimp Inspection Log](#crimp-inspection-log)
 <!-- TOC -->
+
+## Software Repository
+The robot source code can be found in this repository:
+
 
 ## Description
 

--- a/controls/motor_tester/.wpilib/wpilib_preferences.json
+++ b/controls/motor_tester/.wpilib/wpilib_preferences.json
@@ -1,0 +1,1 @@
+{"teamNumber": 6343}

--- a/controls/motor_tester/pyproject.toml
+++ b/controls/motor_tester/pyproject.toml
@@ -6,7 +6,7 @@
 [tool.robotpy]
 
 # Version of robotpy this project depends on
-robotpy_version = "2024.1.1.2"
+robotpy_version = "2024.1.1.3"
 
 # Which extra RobotPy components should be installed
 # -> equivalent to `pip install robotpy[extra1, ...]
@@ -18,7 +18,7 @@ robotpy_extras = [
     # "navx"
     # "pathplannerlib"
     # "phoenix5"
-    # "phoenix6"
+    "phoenix6",
     # "playingwithfusion"
     # "rev"
     # "romi"

--- a/controls/motor_tester/robot.py
+++ b/controls/motor_tester/robot.py
@@ -5,6 +5,8 @@
 import wpilib
 import wpilib.drive
 
+from phoenix6 import hardware, configs
+
 
 class MyRobot(wpilib.TimedRobot):
     def robotInit(self):


### PR DESCRIPTION
Updates to the HW/SW Interface document:

- Added some of the PDP port assignments.
- Changed CANcoder supply voltage from 5V to 12V.
- Changed power source of the VRM and Radio Power Module.
- Changed all motor CAN addresses to _TBD_.  (Help is requested to update these values)
- Added the Ethernet Switch and Limelight.